### PR TITLE
feat: BEXIO_ENABLED_CATEGORIES env var for tool-registration whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,33 @@ Claude uses `find_contact_by_name` to identify the customer, then `get_customer_
 |----------|----------|---------|-------------|
 | `BEXIO_API_TOKEN` | Yes | - | Your Bexio API token |
 | `BEXIO_BASE_URL` | No | `https://api.bexio.com/2.0` | API endpoint URL |
+| `BEXIO_ENABLED_CATEGORIES` | No | (all) | Comma-separated category whitelist — see below |
+
+### Reducing Token Budget — Category Whitelist
+
+All 310 tools are registered by default. For focused workflows or smaller
+models (e.g. Sonnet, Haiku), registering only a subset reduces the system-
+prompt token cost significantly.
+
+Set `BEXIO_ENABLED_CATEGORIES` to a comma-separated list of categories:
+
+```bash
+BEXIO_ENABLED_CATEGORIES=contacts,invoices,purchase,banking,quotes,projects
+```
+
+Available categories: `reference`, `company`, `banking`, `projects`,
+`timetracking`, `accounting`, `purchase`, `files`, `payroll`, `contacts`,
+`invoices`, `orders`, `quotes`, `payments`, `reminders`, `deliveries`,
+`items`, `reports`, `users`, `misc`, `notes`, `tasks`, `stock`, `docs`,
+`positions`.
+
+Unknown names are logged to stderr and ignored. Empty/unset = all enabled
+(backward compatible).
+
+Typical bundles:
+- **Finance-only:** `contacts,invoices,purchase,banking,payments,reports`
+- **Operational (no accounting):** `contacts,projects,timetracking,quotes,orders,tasks`
+- **Read-only dashboards:** `reference,company,reports,contacts,invoices`
 
 ## Command Line Options
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
       "args": ["${__dirname}/dist/index.js"],
       "env": {
         "BEXIO_API_TOKEN": "${user_config.api_token}",
-        "BEXIO_BASE_URL": "${user_config.base_url}"
+        "BEXIO_BASE_URL": "${user_config.base_url}",
+        "BEXIO_ENABLED_CATEGORIES": "${user_config.enabled_categories}"
       }
     }
   },
@@ -39,6 +40,13 @@
       "description": "Bexio API endpoint. Change only if using a custom endpoint.",
       "required": false,
       "default": "https://api.bexio.com/2.0"
+    },
+    "enabled_categories": {
+      "type": "string",
+      "title": "Enabled Tool Categories (optional)",
+      "description": "Comma-separated whitelist to reduce token usage. Example: contacts,invoices,purchase,banking. Leave empty to register all 310 tools. Available: reference, company, banking, projects, timetracking, accounting, purchase, files, payroll, contacts, invoices, orders, quotes, payments, reminders, deliveries, items, reports, users, misc, notes, tasks, stock, docs, positions.",
+      "required": false,
+      "default": ""
     }
   },
   "compatibility": {

--- a/src/tools/categories.ts
+++ b/src/tools/categories.ts
@@ -1,0 +1,113 @@
+/**
+ * Tool category filtering.
+ *
+ * By default all tool categories are registered (~310 tools). For contexts
+ * where token budget matters (e.g. smaller models, focused workflows),
+ * categories can be whitelisted via env var:
+ *
+ *   BEXIO_ENABLED_CATEGORIES=contacts,invoices,bills,banking
+ *
+ * Empty/unset = all categories enabled (backward compatible).
+ */
+
+export type ToolCategory =
+  | "reference"
+  | "company"
+  | "banking"
+  | "projects"
+  | "timetracking"
+  | "accounting"
+  | "purchase"
+  | "files"
+  | "payroll"
+  | "contacts"
+  | "invoices"
+  | "orders"
+  | "quotes"
+  | "payments"
+  | "reminders"
+  | "deliveries"
+  | "items"
+  | "reports"
+  | "users"
+  | "misc"
+  | "notes"
+  | "tasks"
+  | "stock"
+  | "docs"
+  | "positions";
+
+export const ALL_CATEGORIES: ToolCategory[] = [
+  "reference",
+  "company",
+  "banking",
+  "projects",
+  "timetracking",
+  "accounting",
+  "purchase",
+  "files",
+  "payroll",
+  "contacts",
+  "invoices",
+  "orders",
+  "quotes",
+  "payments",
+  "reminders",
+  "deliveries",
+  "items",
+  "reports",
+  "users",
+  "misc",
+  "notes",
+  "tasks",
+  "stock",
+  "docs",
+  "positions",
+];
+
+/**
+ * Parse BEXIO_ENABLED_CATEGORIES env var and return the set of enabled
+ * categories. Empty/unset = all enabled.
+ */
+export function getEnabledCategories(): Set<ToolCategory> {
+  const raw = process.env.BEXIO_ENABLED_CATEGORIES?.trim();
+  if (!raw) {
+    return new Set(ALL_CATEGORIES);
+  }
+
+  const allSet = new Set<string>(ALL_CATEGORIES);
+  const requested = raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+
+  const enabled = new Set<ToolCategory>();
+  const unknown: string[] = [];
+
+  for (const name of requested) {
+    if (allSet.has(name)) {
+      enabled.add(name as ToolCategory);
+    } else {
+      unknown.push(name);
+    }
+  }
+
+  if (unknown.length > 0) {
+    // Logged to stderr via the logger, not stdout (stdio MCP safety).
+    // Using console.error directly here to avoid circular deps with logger.
+    console.error(
+      `[bexio-mcp] BEXIO_ENABLED_CATEGORIES contains unknown categories: ${unknown.join(
+        ", "
+      )}. Valid: ${ALL_CATEGORIES.join(", ")}`
+    );
+  }
+
+  if (enabled.size === 0) {
+    console.error(
+      "[bexio-mcp] BEXIO_ENABLED_CATEGORIES resolved to 0 categories — falling back to all categories."
+    );
+    return new Set(ALL_CATEGORIES);
+  }
+
+  return enabled;
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,6 +11,7 @@
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { BexioClient } from "../bexio-client.js";
+import { getEnabledCategories, type ToolCategory } from "./categories.js";
 
 // Domain imports
 import * as reference from "./reference/index.js";
@@ -45,63 +46,58 @@ export type HandlerFn = (
   args: unknown
 ) => Promise<unknown>;
 
-// Aggregate all tool definitions (310 total)
-const allDefinitions: Tool[] = [
-  ...reference.toolDefinitions,    // 33 tools (contact groups, sectors, salutations, titles, countries, languages, units + update/search)
-  ...company.toolDefinitions,      // 6 tools (company profile, permissions, payment types)
-  ...banking.toolDefinitions,      // 13 tools (bank accounts, currencies, IBAN payments, QR payments)
-  ...projects.toolDefinitions,     // 21 tools (projects, project types, project statuses, milestones, work packages)
-  ...timetracking.toolDefinitions, // 11 tools (timesheets, statuses, business activities, communication types)
-  ...accounting.toolDefinitions,   // 15 tools (accounts, groups, years, entries, VAT, journal)
-  ...purchase.toolDefinitions,     // 23 tools (bills, expenses, purchase orders, outgoing payments)
-  ...files.toolDefinitions,        // 12 tools (files, additional addresses + update/search)
-  ...payroll.toolDefinitions,      // 10 tools (employees, absences, payroll docs - conditional)
-  ...contacts.toolDefinitions,     // 11 tools (list, get, search, update, create, delete, bulk create, restore)
-  ...invoices.toolDefinitions,   // 19 tools (existing 15 + edit, delete, pdf, revert)
-  ...orders.toolDefinitions,     // 13 tools (list, get, create, search, search_by_customer, create_delivery_from, create_invoice_from, edit, delete, pdf, repetition get/edit/delete)
-  ...quotes.toolDefinitions,     // 18 tools (list, get, create, search, search_by_customer, issue, accept, decline, send, create_order_from, create_invoice_from, edit, delete, revert, reissue, mark_sent, pdf, copy)
-  ...payments.toolDefinitions,   // 4 tools
-  ...reminders.toolDefinitions,  // 10 tools (existing 8 + mark_unsent, pdf)
-  ...deliveries.toolDefinitions, // 4 tools
-  ...items.toolDefinitions,      // 8 tools (list, get, create items + list, get taxes + edit, delete, search items)
-  ...reports.toolDefinitions,    // 7 tools
-  ...users.toolDefinitions,      // 8 tools (real users + fictional users)
-  ...misc.toolDefinitions,       // 9 tools
-  ...notes.toolDefinitions,      // 6 tools (list, get, create, update, delete, search)
-  ...tasks.toolDefinitions,      // 8 tools (list, get, create, update, delete, search, priorities, statuses)
-  ...stock.toolDefinitions,      // 4 tools (stock locations, stock areas)
-  ...docs.toolDefinitions,       // 2 tools (document settings, document templates)
-  ...positions.toolDefinitions, // 35 tools (7 position types x 5 CRUD ops on quotes/orders/invoices)
-];
-
-// Aggregate all handlers
-const allHandlers: Record<string, HandlerFn> = {
-  ...reference.handlers,
-  ...company.handlers,
-  ...banking.handlers,
-  ...projects.handlers,
-  ...timetracking.handlers,
-  ...accounting.handlers,
-  ...purchase.handlers,
-  ...files.handlers,
-  ...payroll.handlers,
-  ...contacts.handlers,
-  ...invoices.handlers,
-  ...orders.handlers,
-  ...quotes.handlers,
-  ...payments.handlers,
-  ...reminders.handlers,
-  ...deliveries.handlers,
-  ...items.handlers,
-  ...reports.handlers,
-  ...users.handlers,
-  ...misc.handlers,
-  ...notes.handlers,
-  ...tasks.handlers,
-  ...stock.handlers,
-  ...docs.handlers,
-  ...positions.handlers,
+// Per-category module map — used to build the filtered tool set.
+type CategoryModule = {
+  toolDefinitions: Tool[];
+  handlers: Record<string, HandlerFn>;
 };
+
+const CATEGORY_MODULES: Record<ToolCategory, CategoryModule> = {
+  reference,
+  company,
+  banking,
+  projects,
+  timetracking,
+  accounting,
+  purchase,
+  files,
+  payroll,
+  contacts,
+  invoices,
+  orders,
+  quotes,
+  payments,
+  reminders,
+  deliveries,
+  items,
+  reports,
+  users,
+  misc,
+  notes,
+  tasks,
+  stock,
+  docs,
+  positions,
+};
+
+// Resolve enabled categories once at module load.
+const enabledCategories = getEnabledCategories();
+
+// Build definitions + handlers from enabled categories only.
+const allDefinitions: Tool[] = [];
+const allHandlers: Record<string, HandlerFn> = {};
+
+for (const [name, mod] of Object.entries(CATEGORY_MODULES)) {
+  if (!enabledCategories.has(name as ToolCategory)) continue;
+  allDefinitions.push(...mod.toolDefinitions);
+  Object.assign(allHandlers, mod.handlers);
+}
+
+if (enabledCategories.size < Object.keys(CATEGORY_MODULES).length) {
+  console.error(
+    `[bexio-mcp] Tool filter active: ${allDefinitions.length} tools registered from categories [${[...enabledCategories].join(", ")}]`
+  );
+}
 
 /** Get all tool definitions for registration */
 export function getAllToolDefinitions(): Tool[] {


### PR DESCRIPTION
## Motivation

Registering all ~310 tools puts significant pressure on the system-prompt token budget — especially for focused workflows or smaller models (Sonnet, Haiku). Most real-world integrations only use a subset of Bexio domains (e.g. finance-only: contacts + invoices + purchase + banking).

This PR adds a simple, opt-in whitelist so users can reduce registered tools to what they actually need, without forking or manually editing `src/tools/index.ts`.

## Changes

- **New file `src/tools/categories.ts`** — `ToolCategory` type, `ALL_CATEGORIES` list, `getEnabledCategories()` parser for the env var. Unknown category names are logged to stderr and ignored. Empty-after-parse falls back to all categories (prevents lockout on typos).
- **`src/tools/index.ts`** — refactored to iterate a `CATEGORY_MODULES` map and filter by enabled categories. When a filter is active, logs `[bexio-mcp] Tool filter active: N tools registered from categories [...]` to stderr on startup.
- **`README.md`** — new section "Reducing Token Budget — Category Whitelist" with category list + typical bundles (finance-only, operational, read-only).
- **`manifest.json`** — optional `enabled_categories` field in `user_config` so DXT users get it in the Claude Desktop settings UI.

## Backward compatibility

Empty / unset `BEXIO_ENABLED_CATEGORIES` = all categories enabled. No behavior change for existing users.

## Tested

- Build: `npm run build` clean on this branch (tsc + vite + postbuild).
- Full registration (env unset): all 310 tools registered as before.
- Filtered registration: `BEXIO_ENABLED_CATEGORIES=contacts,invoices` registers only those two categories' tools. Unknown names logged + ignored. All-unknown input falls back to full registration.

## Categories exposed

reference, company, banking, projects, timetracking, accounting, purchase, files, payroll, contacts, invoices, orders, quotes, payments, reminders, deliveries, items, reports, users, misc, notes, tasks, stock, docs, positions.

---

Happy to iterate on naming, defaults, or the bundle examples if you'd prefer different conventions.

— Fabrik4 (Fritz Lang, https://fabrik4.ch) + Claude Opus 4.7