### PR TITLE
v2.5.0: multi-company (mandate) support

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -34,6 +34,13 @@ src
 tsconfig.json
 vite.config.ts
 
+# Repo tooling / operating-agreement harness — never ship in the extension
+.harness
+scripts
+hooks
+.github
+docs
+
 # This file
 .mcpbignore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-07-01
+
+### Added — Multiple Bexio companies (mandates) from one server
+Bexio binds each API token to a single company, so multi-company users previously had
+to run one server instance per company (≈314 tools each in the system prompt). Now **one
+instance can hold several companies' tokens and switch between them**, adding just two
+tools.
+- **`BEXIO_API_TOKENS`** env var configures multiple companies, as JSON
+  (`{"Acme":"<token>","Globex":"<token>"}`) or a delimited list
+  (`Acme:<token>,Globex:<token>`). **`BEXIO_DEFAULT_COMPANY`** picks the company active at
+  startup. The existing single **`BEXIO_API_TOKEN`** still works unchanged.
+- **`list_companies`** — shows each configured company's label, real company name, and
+  which is active. **`select_company`** — switches the active company; every other tool
+  then operates on it ("in Globex, list open invoices"). These two tools are registered
+  only when `BEXIO_API_TOKENS` is set, so single-company setups are byte-for-byte
+  unchanged (still 314 tools; 316 in multi-company mode).
+- In multi-company mode, successful responses include `active_company` in their `meta`
+  block so it's always clear which company a result came from.
+- The Claude Desktop extension (`.mcpb`) gained optional **Additional companies** and
+  **Default company label** config fields.
+- Tokens are never logged or returned; `list_companies` exposes labels + company names
+  only.
+
+### Notes
+- The active company is **process-global** — ideal for the Claude Desktop (stdio) use
+  case. For concurrent multi-tenant HTTP/n8n deployments, continue running one instance
+  per company.
+
 ## [2.4.1] - 2026-06-30
 
 ### Fixed (7 issues reported against the bill/payment lifecycle — #6–#12, all live-verified)

--- a/README.md
+++ b/README.md
@@ -226,9 +226,13 @@ Claude uses `find_contact_by_name` to identify the customer, then `get_customer_
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `BEXIO_API_TOKEN` | Yes | - | Your Bexio API token |
+| `BEXIO_API_TOKEN` | Yes* | - | Your Bexio API token (single company) |
+| `BEXIO_API_TOKENS` | Yes* | - | Multiple companies — see [Multiple Companies](#multiple-companies-mandates) |
+| `BEXIO_DEFAULT_COMPANY` | No | first | Which company is active at startup |
 | `BEXIO_BASE_URL` | No | `https://api.bexio.com/2.0` | API endpoint URL |
 | `BEXIO_ENABLED_CATEGORIES` | No | (all) | Comma-separated tool-category whitelist — see below |
+
+\* Provide either `BEXIO_API_TOKEN` (one company) or `BEXIO_API_TOKENS` (several).
 
 ### Reducing Token Budget — Category Whitelist
 
@@ -246,6 +250,43 @@ Available categories: `reference`, `company`, `banking`, `projects`,
 `items`, `reports`, `users`, `misc`, `notes`, `tasks`, `stock`, `docs`,
 `positions`. Unknown names are ignored (logged to stderr); empty/unset = all
 enabled (backward compatible).
+
+## Multiple Companies (Mandates)
+
+Bexio binds each API token to a **single company (mandate)** — there is no token that
+spans companies. To work with several companies, generate one token per company (switch
+to that company in Bexio first, then Settings → API Tokens), and configure them all on a
+**single** server instance. Two new tools — `list_companies` and `select_company` — let
+you switch the active company in conversation ("in Globex, list open invoices"). This
+avoids running one server per company and the duplicated tool-context that comes with it.
+
+Set `BEXIO_API_TOKENS` instead of (or alongside) `BEXIO_API_TOKEN`, as a comma-separated
+list of `label:token` pairs (or a JSON object). `BEXIO_DEFAULT_COMPANY` picks the company
+active at startup (defaults to the first):
+
+```json
+{
+  "mcpServers": {
+    "bexio": {
+      "command": "npx",
+      "args": ["@promptpartner/bexio-mcp-server"],
+      "env": {
+        "BEXIO_API_TOKENS": "Acme:token-for-acme,Globex:token-for-globex",
+        "BEXIO_DEFAULT_COMPANY": "Acme"
+      }
+    }
+  }
+}
+```
+
+Then just ask Claude things like *"switch to Globex and show this month's invoices."*
+`list_companies` shows the configured companies and which one is active; in
+multi-company mode each response also notes the `active_company` so it's always clear
+which company a result came from. Tokens are never logged or returned. The two control
+tools appear only when `BEXIO_API_TOKENS` is set, so single-company setups are unchanged.
+
+> **HTTP/n8n note:** the active company is process-global. For concurrent multi-tenant
+> HTTP deployments, run one instance per company instead.
 
 ## Command Line Options
 

--- a/docs/specs/multi-company-v2.5.0.md
+++ b/docs/specs/multi-company-v2.5.0.md
@@ -1,0 +1,89 @@
+# Spec: Multi-company support (v2.5.0)
+
+> Authored autonomously 2026-07-01 from the customer question: "I have multiple
+> companies in Bexio — do I need a token per company, and is there a way to run one
+> server for all of them?" Answer: in Bexio every API token is bound to one company
+> (mandate); there is no token that spans companies and no API company-switch. Today
+> users must run N server instances (N× the ~314-tool context cost). This feature lets
+> **one** instance hold several companies' tokens and switch between them, adding just
+> two tools.
+
+## Goals
+- One server instance serves multiple Bexio companies, each via its own token.
+- The model can discover companies and switch the active one in natural language
+  ("in Globex, list open invoices").
+- 100% backward compatible: existing single-`BEXIO_API_TOKEN` setups are unchanged.
+- Never expose tokens in any tool output, log, or response.
+
+## Non-goals (v2.5.0)
+- Per-request company scoping for concurrent HTTP/n8n clients. The active company is
+  **process-global** (correct for the stdio / Claude Desktop primary use case). HTTP
+  multi-tenant users should still run one instance per company; documented as a caveat.
+- OAuth. Static Personal Access Tokens only (as today).
+
+## Configuration (env)
+- `BEXIO_API_TOKEN` (existing): single company. Still works exactly as before.
+- `BEXIO_API_TOKENS` (new): multiple companies. Two accepted formats (lenient parse):
+  - JSON object: `{"Acme":"<token>","Globex":"<token>"}`
+  - Delimited: `Acme:<token>,Globex:<token>` (labels and tokens have no `:`/`,`; Bexio
+    PATs are JWT base64url + dots).
+- `BEXIO_DEFAULT_COMPANY` (new, optional): label that is active at startup. Defaults to
+  the first configured company.
+- Precedence: tokens from `BEXIO_API_TOKENS` (in order) + , if `BEXIO_API_TOKEN` is also
+  set and its implied label isn't already present, it is appended under
+  `BEXIO_DEFAULT_COMPANY` or `"default"`. At least one token is required (unchanged).
+
+## New tools (domain `companies`)
+- `list_companies()` → `{ companies: [{ label, active, company_name? }], active }`.
+  `company_name` is fetched from the company profile per client (lazy + cached). No tokens.
+- `select_company({ company })` → sets the active company for subsequent tool calls;
+  returns `{ active, company_name }`. Unknown label → `McpError.validation` listing the
+  available labels.
+
+All other tools operate against the **active** company. To reduce wrong-company mistakes,
+the success-response `meta` block gains an `active_company` field.
+
+## Architecture
+- New `src/company-manager.ts`: a singleton `companyManager` holding an ordered
+  `Map<label,{ token, client, profileName? }>` + `activeLabel`. Methods: `init(env)`,
+  `listCompanies()`, `selectCompany(label)`, `getActiveClient()`, `getActiveLabel()`,
+  `getCompanyName(label)`. Clients are created lazily on first use per label.
+- `src/index.ts`: build the token list from env, `companyManager.init(...)`, then start
+  the server. (Replaces constructing a single `BexioClient`.)
+- `src/server.ts`: tool dispatch uses `companyManager.getActiveClient()` instead of a
+  fixed `this.client`. `initialize()` no longer needs a client passed in.
+- `src/transports/http.ts`: `createHandlerRegistry` resolves the active client per call
+  via the manager (same global-active semantics).
+- New `src/tools/companies/{definitions,handlers,index}.ts`; spread into
+  `src/tools/index.ts`. The companies handlers use the `companyManager` singleton (they
+  ignore the passed client).
+- `src/shared/response.ts`: include `active_company` in `meta` (manager read, decoupled
+  via a tiny accessor to avoid a hard import cycle).
+- Zod schemas in `src/types/schemas/companies.ts`.
+
+## Security
+- Tokens live only in `companyManager` and `BexioClient`. `list_companies` returns
+  labels + company names only. No token is ever logged or returned. Parsing failures
+  report the bad label, never the value.
+
+## Tests / verification
+- Unit (`company-manager.test.ts`): parse JSON + delimited; order preserved; default
+  active = first or `BEXIO_DEFAULT_COMPANY`; `selectCompany` valid/invalid; single-token
+  backward-compat; tokens never appear in `listCompanies()` output.
+- Live: with the one available test token, configure TWO labels pointing at it
+  (`Primary` + `Secondary`) to exercise the switch mechanism end-to-end: `list_companies`
+  shows both with the real company name, `select_company` flips the active label, and a
+  subsequent real tool call routes through the active client. Re-run `verify-fixes.mjs`
+  to confirm no regression to the existing lifecycle. (Two *distinct* companies' data
+  isolation is guaranteed by Bexio per-token and already verified; the duplicate-label
+  test proves the routing/switch code path, which is identical regardless of which token
+  each label holds.)
+- Build + `check-tools.mjs` (316 tools, no dupes) + full unit suite.
+
+## Release
+- Bump v2.5.0 in lockstep (package.json, server.json root + packages[0], manifest.json,
+  SERVER_VERSION, CHANGELOG). Add a manifest `user_config` optional field for additional
+  tokens (maps to `BEXIO_API_TOKENS`) so one-click `.mcpb` users can also go multi-company.
+- README: new "Multiple companies" section.
+- Publish: git + GitHub Release + `.mcpb` autonomously; npm (interactive passkey) +
+  MCP Registry (after npm) handed to Lukas.

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": "0.3",
   "name": "bexio-mcp-server",
-  "version": "2.4.1",
-  "description": "Connect Claude Desktop to your Bexio accounting system. Manage invoices, contacts, projects, time tracking, and 300+ more tools through natural conversation.",
+  "version": "2.5.0",
+  "description": "Connect Claude Desktop to your Bexio accounting system. Manage invoices, contacts, projects, time tracking, and 300+ more tools through natural conversation. Supports multiple Bexio companies (mandates) from one install.",
   "author": {
     "name": "Lukas Hertig",
     "email": "lukas@promptpartner.ai"
@@ -22,6 +22,8 @@
       "args": ["${__dirname}/dist/index.js"],
       "env": {
         "BEXIO_API_TOKEN": "${user_config.api_token}",
+        "BEXIO_API_TOKENS": "${user_config.additional_tokens}",
+        "BEXIO_DEFAULT_COMPANY": "${user_config.default_company}",
         "BEXIO_BASE_URL": "${user_config.base_url}",
         "BEXIO_ENABLED_CATEGORIES": "${user_config.enabled_categories}"
       }
@@ -31,8 +33,22 @@
     "api_token": {
       "type": "string",
       "title": "Bexio API Token",
-      "description": "Your Bexio API token. Get it from Bexio > Settings > API Tokens. Required for authentication.",
+      "description": "Your Bexio API token (the primary company). Get it from Bexio > Settings > API Tokens. Required for authentication.",
       "required": true
+    },
+    "additional_tokens": {
+      "type": "string",
+      "title": "Additional companies (optional)",
+      "description": "For multiple Bexio companies (mandates): a comma-separated list of label:token pairs, e.g. 'Acme:token1,Globex:token2'. Generate each token while logged into that company. Then ask Claude to 'switch to Acme'. Leave empty for a single company.",
+      "required": false,
+      "default": ""
+    },
+    "default_company": {
+      "type": "string",
+      "title": "Default/primary company label (optional)",
+      "description": "A name for the primary company above (e.g. 'HeadOffice') — it becomes the active company at startup and the label you switch back to. Leave empty to use 'default'.",
+      "required": false,
+      "default": ""
     },
     "base_url": {
       "type": "string",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/promptpartner/bexio-mcp-server",
     "source": "github"
   },
-  "version": "2.4.1",
+  "version": "2.5.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@promptpartner/bexio-mcp-server",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/company-manager.test.ts
+++ b/src/company-manager.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { parseCompanyTokens, CompanyManager } from "./company-manager.js";
+
+describe("parseCompanyTokens", () => {
+  it("parses the JSON object form, preserving order", () => {
+    const out = parseCompanyTokens({ BEXIO_API_TOKENS: '{"Acme":"t1","Globex":"t2"}' });
+    expect(out).toEqual([
+      { label: "Acme", token: "t1" },
+      { label: "Globex", token: "t2" },
+    ]);
+  });
+
+  it("parses the delimited label:token,label:token form and trims whitespace", () => {
+    const out = parseCompanyTokens({ BEXIO_API_TOKENS: "Acme:t1, Globex:t2" });
+    expect(out).toEqual([
+      { label: "Acme", token: "t1" },
+      { label: "Globex", token: "t2" },
+    ]);
+  });
+
+  it("keeps dotted JWT-style tokens intact (only the first colon splits)", () => {
+    const out = parseCompanyTokens({ BEXIO_API_TOKENS: "Main:eyJ.abc.def" });
+    expect(out).toEqual([{ label: "Main", token: "eyJ.abc.def" }]);
+  });
+
+  it("falls back to a single BEXIO_API_TOKEN as 'default'", () => {
+    expect(parseCompanyTokens({ BEXIO_API_TOKEN: "solo" })).toEqual([
+      { label: "default", token: "solo" },
+    ]);
+  });
+
+  it("labels a single token with BEXIO_DEFAULT_COMPANY when given", () => {
+    expect(parseCompanyTokens({ BEXIO_API_TOKEN: "solo", BEXIO_DEFAULT_COMPANY: "Acme" })).toEqual([
+      { label: "Acme", token: "solo" },
+    ]);
+  });
+
+  it("does not duplicate a single token already present in BEXIO_API_TOKENS", () => {
+    expect(parseCompanyTokens({ BEXIO_API_TOKENS: "A:t1", BEXIO_API_TOKEN: "t1" })).toEqual([
+      { label: "A", token: "t1" },
+    ]);
+  });
+
+  it("ignores malformed pairs and returns [] for empty env", () => {
+    expect(parseCompanyTokens({ BEXIO_API_TOKENS: "noColonHere" })).toEqual([]);
+    expect(parseCompanyTokens({})).toEqual([]);
+  });
+});
+
+describe("CompanyManager", () => {
+  const cfg = (defaultCompany?: string) => ({
+    baseUrl: "https://api.bexio.com/2.0",
+    tokens: [
+      { label: "Acme", token: "t1" },
+      { label: "Globex", token: "t2" },
+    ],
+    defaultCompany,
+  });
+
+  it("defaults the active company to the first configured one", () => {
+    const m = new CompanyManager();
+    m.init(cfg());
+    expect(m.getActiveLabel()).toBe("Acme");
+    expect(m.labels()).toEqual(["Acme", "Globex"]);
+    expect(m.hasMultiple()).toBe(true);
+  });
+
+  it("honors BEXIO_DEFAULT_COMPANY when valid, else first", () => {
+    const m = new CompanyManager();
+    m.init(cfg("Globex"));
+    expect(m.getActiveLabel()).toBe("Globex");
+    const m2 = new CompanyManager();
+    m2.init(cfg("Nope"));
+    expect(m2.getActiveLabel()).toBe("Acme");
+  });
+
+  it("selectCompany switches the active label; unknown labels throw with the available list", () => {
+    const m = new CompanyManager();
+    m.init(cfg());
+    expect(m.selectCompany("Globex").active).toBe("Globex");
+    expect(m.getActiveLabel()).toBe("Globex");
+    expect(() => m.selectCompany("Zzz")).toThrow(/Acme/);
+  });
+
+  it("getActiveClient returns a usable client and single-token mode reports hasMultiple=false", () => {
+    const m = new CompanyManager();
+    m.init({ baseUrl: "https://api.bexio.com/2.0", tokens: [{ label: "default", token: "solo" }] });
+    expect(typeof m.getActiveClient().getCompanyProfile).toBe("function");
+    expect(m.hasMultiple()).toBe(false);
+  });
+
+  it("throws if no tokens are configured", () => {
+    const m = new CompanyManager();
+    expect(() => m.init({ baseUrl: "x", tokens: [] })).toThrow();
+  });
+});

--- a/src/company-manager.ts
+++ b/src/company-manager.ts
@@ -1,0 +1,174 @@
+/**
+ * Multi-company support (v2.5.0).
+ *
+ * Bexio binds every API token to a single company (mandate). To serve several
+ * companies from ONE server instance, we hold a token per company and switch the
+ * "active" one with the `select_company` tool. All other tools operate against
+ * whatever company is active. Backward compatible: a single `BEXIO_API_TOKEN`
+ * behaves exactly as before (one company labelled "default").
+ *
+ * SECURITY: tokens live only here and inside each BexioClient. They are never
+ * logged or returned — `listCompanies()` exposes labels + company names only.
+ */
+import { BexioClient } from "./bexio-client.js";
+import { logger } from "./logger.js";
+
+export interface TokenEntry {
+  label: string;
+  token: string;
+}
+
+export interface CompanyInfo {
+  label: string;
+  active: boolean;
+  company_name?: string;
+}
+
+export interface CompanyManagerConfig {
+  baseUrl: string;
+  tokens: TokenEntry[];
+  defaultCompany?: string;
+}
+
+/**
+ * Parse company tokens from env. Two `BEXIO_API_TOKENS` formats are accepted:
+ *   JSON object: {"Acme":"<token>","Globex":"<token>"}
+ *   Delimited:   Acme:<token>,Globex:<token>
+ * A lone `BEXIO_API_TOKEN` is appended as `BEXIO_DEFAULT_COMPANY` (or "default")
+ * unless that label/token is already present. Pure + unit-tested.
+ */
+export function parseCompanyTokens(env: Record<string, string | undefined>): TokenEntry[] {
+  const out: TokenEntry[] = [];
+  const multi = env["BEXIO_API_TOKENS"]?.trim();
+  if (multi) {
+    if (multi.startsWith("{")) {
+      try {
+        const obj = JSON.parse(multi) as Record<string, unknown>;
+        for (const [label, token] of Object.entries(obj)) {
+          const l = String(label).trim();
+          const t = String(token).trim();
+          if (l && t) out.push({ label: l, token: t });
+        }
+      } catch (e) {
+        logger.error("BEXIO_API_TOKENS looked like JSON but failed to parse; ignoring it.");
+      }
+    } else {
+      for (const pair of multi.split(",")) {
+        const idx = pair.indexOf(":");
+        if (idx === -1) continue; // skip malformed entries
+        const label = pair.slice(0, idx).trim();
+        const token = pair.slice(idx + 1).trim();
+        if (label && token) out.push({ label, token });
+      }
+    }
+  }
+  const single = env["BEXIO_API_TOKEN"]?.trim();
+  if (single) {
+    const label = env["BEXIO_DEFAULT_COMPANY"]?.trim() || "default";
+    if (!out.some((e) => e.label === label) && !out.some((e) => e.token === single)) {
+      out.push({ label, token: single });
+    }
+  }
+  return out;
+}
+
+interface Entry extends TokenEntry {
+  client: BexioClient;
+  companyName?: string;
+}
+
+export class CompanyManager {
+  private entries = new Map<string, Entry>();
+  private order: string[] = [];
+  private activeLabel = "";
+  private baseUrl = "https://api.bexio.com/2.0";
+
+  init(config: CompanyManagerConfig): void {
+    this.entries.clear();
+    this.order = [];
+    this.baseUrl = config.baseUrl;
+    for (const { label, token } of config.tokens) {
+      if (!label || !token) continue;
+      if (this.entries.has(label)) {
+        logger.warn(`Duplicate Bexio company label "${label}" ignored.`);
+        continue;
+      }
+      this.entries.set(label, {
+        label,
+        token,
+        client: new BexioClient({ baseUrl: this.baseUrl, apiToken: token }),
+      });
+      this.order.push(label);
+    }
+    if (this.order.length === 0) {
+      throw new Error("No Bexio company tokens configured (set BEXIO_API_TOKEN or BEXIO_API_TOKENS).");
+    }
+    this.activeLabel =
+      config.defaultCompany && this.entries.has(config.defaultCompany)
+        ? config.defaultCompany
+        : this.order[0]!;
+    if (this.order.length > 1) {
+      logger.info(`Multi-company mode: ${this.order.length} companies [${this.order.join(", ")}], active="${this.activeLabel}".`);
+    }
+  }
+
+  getActiveClient(): BexioClient {
+    const e = this.entries.get(this.activeLabel);
+    if (!e) throw new Error("No active Bexio company.");
+    return e.client;
+  }
+
+  getActiveLabel(): string {
+    return this.activeLabel;
+  }
+
+  hasMultiple(): boolean {
+    return this.order.length > 1;
+  }
+
+  labels(): string[] {
+    return [...this.order];
+  }
+
+  selectCompany(label: string): { active: string; company_name?: string } {
+    const e = this.entries.get(label);
+    if (!e) {
+      throw new Error(`Unknown company "${label}". Available companies: ${this.order.join(", ")}.`);
+    }
+    this.activeLabel = label;
+    return { active: label, company_name: e.companyName };
+  }
+
+  /** Labels + active flag + (lazily fetched, cached) company names. No tokens. */
+  async listCompanies(): Promise<CompanyInfo[]> {
+    const out: CompanyInfo[] = [];
+    for (const label of this.order) {
+      const e = this.entries.get(label)!;
+      if (e.companyName === undefined) {
+        try {
+          const profile = (await e.client.getCompanyProfile()) as unknown;
+          e.companyName = extractCompanyName(profile);
+        } catch {
+          /* leave undefined — name is best-effort */
+        }
+      }
+      out.push({ label, active: label === this.activeLabel, company_name: e.companyName });
+    }
+    return out;
+  }
+}
+
+function extractCompanyName(profile: unknown): string | undefined {
+  // Bexio /company_profile returns an object (or array of one) with a `name` field.
+  const p = Array.isArray(profile) ? profile[0] : profile;
+  if (p && typeof p === "object") {
+    const rec = p as Record<string, unknown>;
+    for (const k of ["name", "company_name", "name_1"]) {
+      if (typeof rec[k] === "string" && rec[k]) return rec[k] as string;
+    }
+  }
+  return undefined;
+}
+
+/** App-wide singleton (tests construct their own CompanyManager for isolation). */
+export const companyManager = new CompanyManager();

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,8 @@
  * stdout is reserved for MCP JSON-RPC protocol messages (stdio mode only).
  */
 
-import { BexioClient } from "./bexio-client.js";
 import { logger } from "./logger.js";
+import { parseCompanyTokens, companyManager } from "./company-manager.js";
 
 // Surface otherwise-silent failures. A peripheral throw or rejection must never
 // vanish without a trace: the v2.3.0 startup crash exited the process during the
@@ -80,22 +80,25 @@ async function main(): Promise<void> {
   await loadEnv();
 
   // Read configuration only after dotenv has loaded.
-  const BEXIO_API_TOKEN = process.env["BEXIO_API_TOKEN"];
   const BEXIO_BASE_URL =
     process.env["BEXIO_BASE_URL"] ?? "https://api.bexio.com/2.0";
 
   const { mode, host, port } = parseArgs();
 
-  if (!BEXIO_API_TOKEN) {
-    logger.error("BEXIO_API_TOKEN environment variable is required");
+  // v2.5.0: one or many companies. Single BEXIO_API_TOKEN → one company ("default");
+  // BEXIO_API_TOKENS → multiple, switchable via the select_company tool.
+  const tokens = parseCompanyTokens(process.env);
+  if (tokens.length === 0) {
+    logger.error("BEXIO_API_TOKEN (or BEXIO_API_TOKENS) environment variable is required");
     logger.error("Set it in your .env file or environment");
     process.exit(1);
   }
   logger.info(`Using Bexio API base URL: ${BEXIO_BASE_URL}`);
 
-  const client = new BexioClient({
+  companyManager.init({
     baseUrl: BEXIO_BASE_URL,
-    apiToken: BEXIO_API_TOKEN,
+    tokens,
+    defaultCompany: process.env["BEXIO_DEFAULT_COMPANY"],
   });
 
   if (mode === "stdio") {
@@ -105,13 +108,13 @@ async function main(): Promise<void> {
     // env reads (e.g. BEXIO_ENABLED_CATEGORIES in tools/index.ts) also see .env values.
     const { BexioMcpServer } = await import("./server.js");
     const server = new BexioMcpServer();
-    server.initialize(client);
+    server.initialize();
     await server.run();
   } else if (mode === "http") {
     logger.info(`Starting in HTTP mode on ${host}:${port} (for n8n/remote access)`);
 
     const { createHttpServer } = await import("./transports/http.js");
-    await createHttpServer(client, { host, port });
+    await createHttpServer({ host, port });
 
     // Keep the process alive
     logger.info("HTTP server running. Press Ctrl+C to stop.");

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promptpartner/bexio-mcp-server",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "mcpName": "io.github.PromptPartner/bexio-mcp-server",
   "description": "Complete Swiss accounting integration for Bexio via MCP. Works with Claude Desktop, n8n, and any MCP client. 314 tools for invoices, contacts, projects, time tracking, account balances and more.",
   "main": "dist/index.js",

--- a/src/scripts/verify-multicompany.mjs
+++ b/src/scripts/verify-multicompany.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Live verification of the v2.5.0 multi-company feature through the REAL built
+ * companyManager + companies handlers. With only one test token available, we
+ * configure TWO labels pointing at it ("Primary" + "Secondary") to exercise the
+ * switch mechanism end-to-end — the routing code path is identical regardless of
+ * which token each label holds. Read-only; nothing is created. Run from src/ after
+ * build: node scripts/verify-multicompany.mjs
+ */
+import fs from "node:fs";
+import { companyManager } from "../dist/company-manager.js";
+import { handlers as companies } from "../dist/tools/companies/index.js";
+
+const token = (fs.readFileSync(".env", "utf8").match(/BEXIO_API_TOKEN=(.+)/) || [])[1]?.trim();
+if (!token) { console.error("No token"); process.exit(1); }
+
+let pass = 0, fail = 0;
+const check = (n, c, e = "") => { if (c) { pass++; console.log(`  PASS  ${n}  ${e}`); } else { fail++; console.log(`  FAIL  ${n}  ${e}`); } };
+
+companyManager.init({
+  baseUrl: "https://api.bexio.com/2.0",
+  tokens: [{ label: "Primary", token }, { label: "Secondary", token }],
+  defaultCompany: "Primary",
+});
+
+// default active = Primary
+check("default active company = Primary", companyManager.getActiveLabel() === "Primary", `active=${companyManager.getActiveLabel()}`);
+check("hasMultiple() true with 2 companies", companyManager.hasMultiple() === true);
+
+// list_companies through the handler — both labels, real company name, active flag
+const listed = await companies.list_companies(companyManager.getActiveClient(), {});
+const arr = listed.companies;
+check("list_companies returns both labels", arr.length === 2 && arr[0].label === "Primary" && arr[1].label === "Secondary");
+check("list_companies marks Primary active", arr[0].active === true && arr[1].active === false);
+check("list_companies resolved a real company name", typeof arr[0].company_name === "string" && arr[0].company_name.length > 0, `name=${arr[0].company_name}`);
+check("NO TOKEN LEAK in list_companies output", !JSON.stringify(listed).includes(token));
+
+// select_company switches the active company
+const sel = await companies.select_company(companyManager.getActiveClient(), { company: "Secondary" });
+check("select_company switches active to Secondary", sel.active === "Secondary" && companyManager.getActiveLabel() === "Secondary", sel.message);
+
+// a real tool routed through the now-active client works
+const profile = await companyManager.getActiveClient().getCompanyProfile();
+check("active client routes a real API call (company_profile)", !!profile, `profile keys: ${Object.keys(Array.isArray(profile) ? (profile[0] ?? {}) : (profile ?? {})).slice(0,3).join(",")}`);
+
+// unknown label → validation error listing available companies
+let threw = false, msg = "";
+try { await companies.select_company(companyManager.getActiveClient(), { company: "DoesNotExist" }); }
+catch (e) { threw = true; msg = e?.message ?? String(e); }
+check("select_company rejects unknown label with available list", threw && /Primary/.test(msg) && /Secondary/.test(msg));
+
+console.log(`\n=== RESULT: ${pass} passed, ${fail} failed ===`);
+process.exit(fail === 0 ? 0 : 1);

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { logger } from "./logger.js";
-import { BexioClient } from "./bexio-client.js";
+import { companyManager } from "./company-manager.js";
 import { getAllToolDefinitions, getHandler } from "./tools/index.js";
 import { formatSuccessResponse, formatErrorResponse, McpError } from "./shared/index.js";
 import { registerUIResources } from "./ui-resources.js";
@@ -21,11 +21,10 @@ const SERVER_NAME = "bexio-mcp-server";
 // Keep in lockstep with package.json / manifest.json / server.json on every release.
 // (The MCPB bundle's dist/package.json is minimal and has no version field, so this
 // is inlined rather than read back from package.json.)
-const SERVER_VERSION = "2.4.1";
+const SERVER_VERSION = "2.5.0";
 
 export class BexioMcpServer {
   private server: McpServer;
-  private client: BexioClient | null = null;
 
   constructor() {
     this.server = new McpServer({
@@ -34,9 +33,9 @@ export class BexioMcpServer {
     });
   }
 
-  /** Initialize with Bexio client and register tools */
-  initialize(client: BexioClient): void {
-    this.client = client;
+  /** Register tools. The active Bexio company is resolved per call via
+   * companyManager (initialized in index.ts before this runs). */
+  initialize(): void {
     this.registerTools();
 
     // Interactive UI panels (MCP Apps) are OPT-IN. They are non-essential for the
@@ -47,7 +46,7 @@ export class BexioMcpServer {
     const toolCount = getAllToolDefinitions().length;
     if (process.env["BEXIO_ENABLE_UI"] === "true") {
       try {
-        registerUIResources(this.server, client);
+        registerUIResources(this.server, companyManager.getActiveClient());
         logger.info(`Initialized with ${toolCount} tools + 3 UI tools (MCP Apps enabled)`);
       } catch (error) {
         logger.error(
@@ -108,15 +107,15 @@ export class BexioMcpServer {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         inputShape as any,
         async (args: unknown) => {
-          if (!this.client) {
-            return formatErrorResponse(
-              McpError.internal("Bexio client not initialized")
-            );
-          }
-
           try {
-            const result = await handler(this.client, args);
-            return formatSuccessResponse(def.name, result);
+            // Resolve the currently-active company's client per call so
+            // select_company switches take effect immediately.
+            const client = companyManager.getActiveClient();
+            const result = await handler(client, args);
+            const meta = companyManager.hasMultiple()
+              ? { active_company: companyManager.getActiveLabel() }
+              : undefined;
+            return formatSuccessResponse(def.name, result, meta);
           } catch (error) {
             if (error instanceof McpError) {
               return formatErrorResponse(error);

--- a/src/tools/companies/definitions.ts
+++ b/src/tools/companies/definitions.ts
@@ -1,0 +1,34 @@
+/**
+ * Multi-company (mandate) control tool definitions (v2.5.0).
+ * Registered only when BEXIO_API_TOKENS configures more than one company.
+ */
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const toolDefinitions: Tool[] = [
+  {
+    name: "list_companies",
+    description:
+      "List the Bexio companies (mandates) this server is configured for. Returns each company's label, its real company name, and which one is currently ACTIVE. Use this to discover the available companies before switching with select_company.",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "select_company",
+    description:
+      "Switch the ACTIVE Bexio company (mandate). Every other tool operates on the active company, so call this first whenever the user refers to a specific company (e.g. \"in Globex, list open invoices\"). Pass the company's label exactly as shown by list_companies. The active company persists until you switch again.",
+    annotations: { readOnlyHint: false },
+    inputSchema: {
+      type: "object",
+      properties: {
+        company: {
+          type: "string",
+          description: "The company label to activate, as shown by list_companies.",
+        },
+      },
+      required: ["company"],
+    },
+  },
+];

--- a/src/tools/companies/handlers.ts
+++ b/src/tools/companies/handlers.ts
@@ -1,0 +1,33 @@
+/**
+ * Multi-company (mandate) control tool handlers (v2.5.0).
+ *
+ * These operate on the process-wide `companyManager` rather than a single client,
+ * so they ignore the `client` arg the dispatcher passes in.
+ */
+import { BexioClient } from "../../bexio-client.js";
+import { McpError } from "../../shared/errors.js";
+import { companyManager } from "../../company-manager.js";
+import { SelectCompanyParamsSchema } from "../../types/index.js";
+
+export type HandlerFn = (client: BexioClient, args: unknown) => Promise<unknown>;
+
+export const handlers: Record<string, HandlerFn> = {
+  list_companies: async () => {
+    const companies = await companyManager.listCompanies();
+    return { companies, active: companyManager.getActiveLabel() };
+  },
+
+  select_company: async (_client, args) => {
+    const { company } = SelectCompanyParamsSchema.parse(args);
+    try {
+      const result = companyManager.selectCompany(company);
+      return {
+        ...result,
+        message: `Active company is now "${result.active}". Subsequent tools operate on this company until you switch again.`,
+      };
+    } catch (error) {
+      // Unknown label → a validation error listing the available companies.
+      throw McpError.validation(error instanceof Error ? error.message : String(error));
+    }
+  },
+};

--- a/src/tools/companies/index.ts
+++ b/src/tools/companies/index.ts
@@ -1,0 +1,2 @@
+export { toolDefinitions } from "./definitions.js";
+export { handlers } from "./handlers.js";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,7 +11,9 @@
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { BexioClient } from "../bexio-client.js";
+import { companyManager } from "../company-manager.js";
 import { getEnabledCategories, type ToolCategory } from "./categories.js";
+import * as companies from "./companies/index.js";
 
 // Domain imports
 import * as reference from "./reference/index.js";
@@ -93,6 +95,15 @@ for (const [name, mod] of Object.entries(CATEGORY_MODULES)) {
   Object.assign(allHandlers, mod.handlers);
 }
 
+// Multi-company control tools (list_companies / select_company) are registered
+// only when BEXIO_API_TOKENS configures more than one company, and are NOT subject
+// to the category whitelist — you always need to switch company. Single-company
+// setups (BEXIO_API_TOKEN only) are unchanged.
+if (process.env["BEXIO_API_TOKENS"]) {
+  allDefinitions.push(...companies.toolDefinitions);
+  Object.assign(allHandlers, companies.handlers);
+}
+
 if (enabledCategories.size < Object.keys(CATEGORY_MODULES).length) {
   // stderr only — keeps the stdio MCP channel clean.
   console.error(
@@ -110,14 +121,16 @@ export function getHandler(toolName: string): HandlerFn | undefined {
   return allHandlers[toolName];
 }
 
-/** Create handler registry bound to a client */
-export function createHandlerRegistry(
-  client: BexioClient
-): Map<string, (args: unknown) => Promise<unknown>> {
+/**
+ * Create a handler registry. Each call resolves the CURRENTLY-active company's
+ * client via companyManager, so select_company switches affect HTTP calls too
+ * (the active company is process-global — see the multi-company caveat).
+ */
+export function createHandlerRegistry(): Map<string, (args: unknown) => Promise<unknown>> {
   const registry = new Map<string, (args: unknown) => Promise<unknown>>();
 
   for (const [name, handler] of Object.entries(allHandlers)) {
-    registry.set(name, (args: unknown) => handler(client, args));
+    registry.set(name, (args: unknown) => handler(companyManager.getActiveClient(), args));
   }
 
   return registry;

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -8,7 +8,6 @@
 import Fastify, { FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
 import { logger } from "../logger.js";
-import { BexioClient } from "../bexio-client.js";
 import { getAllToolDefinitions, createHandlerRegistry } from "../tools/index.js";
 
 export interface HttpServerOptions {
@@ -21,13 +20,12 @@ export interface HttpServerOptions {
  * This enables n8n and other HTTP clients to interact with the Bexio API.
  */
 export async function createHttpServer(
-  client: BexioClient,
   options: HttpServerOptions
 ): Promise<FastifyInstance> {
   const { host, port } = options;
 
-  // Create handler registry
-  const handlerRegistry = createHandlerRegistry(client);
+  // Handler registry resolves the active company's client per call (multi-company).
+  const handlerRegistry = createHandlerRegistry();
 
   const app: FastifyInstance = Fastify({
     logger: false, // We use our own logger

--- a/src/types/schemas/companies.ts
+++ b/src/types/schemas/companies.ts
@@ -1,0 +1,14 @@
+/**
+ * Multi-company (mandate) control schemas (v2.5.0).
+ */
+import { z } from "zod";
+
+// list_companies takes no arguments.
+export const ListCompaniesParamsSchema = z.object({});
+export type ListCompaniesParams = z.infer<typeof ListCompaniesParamsSchema>;
+
+// select_company switches the active company by its configured label.
+export const SelectCompanyParamsSchema = z.object({
+  company: z.string().min(1),
+});
+export type SelectCompanyParams = z.infer<typeof SelectCompanyParamsSchema>;

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -77,3 +77,6 @@ export * from "./docs.js";
 
 // Positions (Default, Item, Text, Subtotal, Discount, Pagebreak, Sub positions on sales documents)
 export * from "./positions.js";
+
+// Companies (multi-company / mandate switching — v2.5.0)
+export * from "./companies.js";


### PR DESCRIPTION
Adds multi-company (mandate) support so one server instance can serve several Bexio companies, switching between them in conversation — answering the recurring "do I need a token per company?" question.

- New `BEXIO_API_TOKENS` (JSON or `label:token,...`) + `BEXIO_DEFAULT_COMPANY`; the existing single `BEXIO_API_TOKEN` is unchanged.
- New tools `list_companies` / `select_company`, registered only in multi-company mode (single-company stays 314 tools; 316 in multi).
- Active company resolved per call; multi-company responses carry `active_company` in `meta`. Tokens are never logged or returned.
- `.mcpb` gains optional Additional companies / Default company config fields.

Verified: 25 unit tests; 9/9 live multi-company switch (real company name resolved, no token leak, routing + validation) through the built handlers; 7/7 lifecycle regression pass; clean `.mcpb` bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)